### PR TITLE
Added missing field to metrics collection docs

### DIFF
--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import pymongo
 from mongoalchemy import fields
 from mongoalchemy.document import Document
+from collections import defaultdict
 
 from adsdata import utils
 
@@ -404,11 +405,13 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
             refereed = True
         reference_collection = session.get_collection('references')
         ref_norm = 0.0
+        rn_citations_hist = defaultdict(float)
         for citation in citations:
             try:
                 res = reference_collection.find_one({'_id':citation})
                 Nrefs = len(res.get('references',[]))
                 ref_norm += 1.0/float(max(5, Nrefs))
+                rn_citations_hist[citation[:4]] += ref_norm
             except:
                 pass
         doc['refereed'] = refereed
@@ -419,6 +422,7 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
         doc['an_citations'] = float(doc['citation_num'])/float(age)
         doc['an_refereed_citations'] = float(doc['refereed_citation_num'])/float(age)
         doc['rn_citations'] = ref_norm
+        doc['rn_citations_hist']=dict(rn_citations_hist)
 
     @classmethod
     def post_load_data(cls, session, source_collection):

--- a/test/test.py
+++ b/test/test.py
@@ -410,7 +410,10 @@ class TestMetrics(AdsdataTestCase):
                                'citations': [u'1983ARA&A..21..373O', u'2000JOptB...2..534W', u'2000PhRvL..84.2094A', u'2001AJ....122..308G', u'2011foobar........X'],
                                'refereed_citations': [u'1983ARA&A..21..373O', u'2000JOptB...2..534W', u'2000PhRvL..84.2094A', u'2001AJ....122..308G'],
                                'author_num': 1,
-                               'an_refereed_citations': 0.042105263157894736
+                               'an_refereed_citations': 0.042105263157894736,
+                               'rn_citations_hist': {u'1983': 0.018867924528301886,
+                                                     u'2000': 0.089170328250193845,
+                                                     u'2001': 0.070302403721891962}
                                })
     def test_build_metrics_data(self):
         load_data(self.config)


### PR DESCRIPTION
Updating the metrics module to use the new metrics_data collection in adsdata, it turned out that one field was missing in the docs. 
