### PR TITLE
Bug fix: ticket_544 and author_num of 0 fix

### DIFF
--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -406,12 +406,14 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
         reference_collection = session.get_collection('references')
         ref_norm = 0.0
         rn_citations_hist = defaultdict(float)
+        rn_citation_data = []
         for citation in citations:
             try:
                 res = reference_collection.find_one({'_id':citation})
                 Nrefs = len(res.get('references',[]))
                 ref_norm += 1.0/float(max(5, Nrefs))
                 rn_citations_hist[citation[:4]] += ref_norm
+                rn_citation_data.append({'bibcode':citation,'ref_norm':ref_norm})
             except:
                 pass
         doc['refereed'] = refereed
@@ -422,6 +424,7 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
         doc['an_citations'] = float(doc['citation_num'])/float(age)
         doc['an_refereed_citations'] = float(doc['refereed_citation_num'])/float(age)
         doc['rn_citations'] = ref_norm
+        doc['rn_citation_data'] = rn_citation_data
         doc['rn_citations_hist']=dict(rn_citations_hist)
 
     @classmethod
@@ -579,7 +582,7 @@ class Authors(DataFileCollection, MetricsDataCollection):
             authors = entry.get('authors',[])
         except:
             authors = []
-        doc['author_num'] = len(authors)
+        doc['author_num'] = max(len(authors),1)
 
     def __str__(self):
         return "Authors(%s)" % self.bibcode

--- a/test/test.py
+++ b/test/test.py
@@ -402,6 +402,7 @@ class TestMetrics(AdsdataTestCase):
         self.assertEqual(doc, {'_id': '1920ApJ....51....4D',
                                'refereed': True,
                                'rn_citations': 0.070302403721891962,
+                               'rn_citation_data': [{'bibcode':u'1983ARA&A..21..373O','ref_norm':0.018867924528301886}, {'bibcode':u'2000JOptB...2..534W', 'ref_norm': 0.037735849056603772}, {'bibcode':u'2000PhRvL..84.2094A', 'ref_norm': 0.051434479193590073}, {'bibcode':u'2001AJ....122..308G','ref_norm': 0.070302403721891962}],
                                'downloads': [0, 0, 0, 5, 3, 3, 2, 6, 1, 8, 7, 2, 7, 3, 2, 0, 4, 5],
                                'reads': [0, 0, 0, 5, 4, 3, 3, 6, 1, 8, 12, 4, 7, 3, 2, 2, 8, 0],
                                'an_citations': 0.052631578947368418,


### PR DESCRIPTION
A field 'rn_citation_data' has been added that keep the association between citation bibcode and contribution. We don't know in advance which citations will be self-citations, so the contributions of those will have to be removed afterwards (in the metrics module).

Secondly, if the number of authors is found to be zero, it is set to 1. We don't want to exclude records in the metrics with zero authors (which could be records with citations and e.g. only a review author)
