### PR TITLE
ticket_548: wrong data was used for 'ref_norm'

### DIFF
--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -411,9 +411,10 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
             try:
                 res = reference_collection.find_one({'_id':citation})
                 Nrefs = len(res.get('references',[]))
-                ref_norm += 1.0/float(max(5, Nrefs))
+                Nrefs_normalized = 1.0/float(max(5, Nrefs))
+                ref_norm += Nrefs_normalized
                 rn_citations_hist[citation[:4]] += ref_norm
-                rn_citation_data.append({'bibcode':citation,'ref_norm':ref_norm})
+                rn_citation_data.append({'bibcode':citation,'ref_norm':Nrefs_normalized})
             except:
                 pass
         doc['refereed'] = refereed

--- a/test/test.py
+++ b/test/test.py
@@ -402,7 +402,7 @@ class TestMetrics(AdsdataTestCase):
         self.assertEqual(doc, {'_id': '1920ApJ....51....4D',
                                'refereed': True,
                                'rn_citations': 0.070302403721891962,
-                               'rn_citation_data': [{'bibcode':u'1983ARA&A..21..373O','ref_norm':0.018867924528301886}, {'bibcode':u'2000JOptB...2..534W', 'ref_norm': 0.037735849056603772}, {'bibcode':u'2000PhRvL..84.2094A', 'ref_norm': 0.051434479193590073}, {'bibcode':u'2001AJ....122..308G','ref_norm': 0.070302403721891962}],
+                               'rn_citation_data': [{'bibcode':u'1983ARA&A..21..373O','ref_norm':0.018867924528301886}, {'bibcode':u'2000JOptB...2..534W', 'ref_norm': 0.018867924528301886}, {'bibcode':u'2000PhRvL..84.2094A', 'ref_norm': 0.013698630136986301}, {'bibcode':u'2001AJ....122..308G','ref_norm': 0.018867924528301886}],
                                'downloads': [0, 0, 0, 5, 3, 3, 2, 6, 1, 8, 7, 2, 7, 3, 2, 0, 4, 5],
                                'reads': [0, 0, 0, 5, 4, 3, 3, 6, 1, 8, 12, 4, 7, 3, 2, 2, 8, 0],
                                'an_citations': 0.052631578947368418,


### PR DESCRIPTION
In 'rn_citation_data' the cumulative quantity was used for the reference-normalized citation count, rather than the per-paper normalized count!
