### PR TITLE
Replacing accno collection with canonical

### DIFF
--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -489,18 +489,17 @@ class SimbadObjects(DataFileCollection, DocsDataCollection):
         return "Simbad_objs(%s): %s, %s" % (self.bibcode, self.type, self.id)
 
 
-#  DEPRECATED: ISSUE #44
-# class Accno(DataFileCollection):
-#
-#     bibcode = fields.StringField(_id=True)
-#     accno = fields.StringField()
-#
-#     config_collection_name = 'accnos'
-#     field_order = [bibcode,accno]
-#
-#     def __str__(self):
-#         return "Accno(%s): %s" % (self.bibcode, self.accno)
-#
+class Accno(DataFileCollection):
+
+    bibcode = fields.StringField(_id=True)
+    accno = fields.StringField()
+
+    config_collection_name = 'accnos'
+    field_order = [bibcode,accno]
+
+    def __str__(self):
+        return "Accno(%s): %s" % (self.bibcode, self.accno)
+
 
 #  DEPRECATED: ISSUE #44
 # class EprintMatches(DataFileCollection):

--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -489,17 +489,28 @@ class SimbadObjects(DataFileCollection, DocsDataCollection):
         return "Simbad_objs(%s): %s, %s" % (self.bibcode, self.type, self.id)
 
 
-class Accno(DataFileCollection):
+class Canonical(DataFileCollection):
 
     bibcode = fields.StringField(_id=True)
-    accno = fields.StringField()
 
-    config_collection_name = 'accnos'
-    field_order = [bibcode,accno]
+    config_collection_name = 'canonical'
+    field_order = [bibcode]
 
     def __str__(self):
-        return "Accno(%s): %s" % (self.bibcode, self.accno)
+        return "Canonical bibcode: %s" % (self.bibcode)
 
+
+#  DEPRECATED: ISSUE #44
+# class Accno(DataFileCollection):
+#
+#     bibcode = fields.StringField(_id=True)
+#     accno = fields.StringField()
+#
+#     config_collection_name = 'accnos'
+#     field_order = [bibcode,accno]
+#
+#     def __str__(self):
+#         return "Accno(%s): %s" % (self.bibcode, self.accno)
 
 #  DEPRECATED: ISSUE #44
 # class EprintMatches(DataFileCollection):

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
     op.set_usage("usage: build_docs.py [options] [%s]" % '|'.join(commands.map.keys()))
     op.add_option('--do', dest="do", action="append", default=['docs', 'metrics'])
     op.add_option('-i', '--infile', dest="infile", action="store")
-    op.add_option('-s', '--source_model', dest="source_model", action="store", default="Accno")
+    op.add_option('-s', '--source_model', dest="source_model", action="store", default="Canonical")
     op.add_option('-t','--threads', dest="threads", action="store", type=int, default=int(cpu_count() / 2))
     op.add_option('-l','--limit', dest="limit", action="store", type=int)
     op.add_option('-r','--remove', dest="remove", action="store_true", default=False)

--- a/scripts/deletions.py
+++ b/scripts/deletions.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
     
     op = OptionParser()
     op.set_usage("usage: deletions.py [options] [%s]" % '|'.join(commands.map.keys()))
-    op.add_option('-a', '--authority', dest="authority", action="store", default=models.Accno.config_collection_name,
+    op.add_option('-a', '--authority', dest="authority", action="store", default=models.Canonical.config_collection_name,
                   help="collection to use as the authority")
     op.add_option('-s', '--subject', dest="subject", action="store", default='docs',
                   help="collection to be examined for possible deletions")


### PR DESCRIPTION
Accno collection has been replaced with canonical collection. A new model was added to ensure that it is copied in the sync_mongo.py script, and used for deletions.py as the 'authority' collection. Issue #48.