### PR TITLE
adsdata issue55: fix for addition of reference_num column

### DIFF
--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -409,6 +409,7 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
             refereed = True
         reference_collection = session.get_collection('references')
         ref_norm = 0.0
+        rn_citations_hist = defaultdict(float)
         rn_citation_data = []
         res = reference_collection.find_one({'_id':bibcode})
         try:
@@ -428,6 +429,7 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
                 Nrefs = len(res.get('references',[]))
                 Nrefs_normalized = 1.0/float(max(5, Nrefs))
                 ref_norm += Nrefs_normalized
+                rn_citations_hist[citation[:4]] += ref_norm
                 rn_citation_data.append({'bibcode':citation,'ref_norm':Nrefs_normalized,'auth_norm':auth_norm})
             except:
                 pass
@@ -440,6 +442,7 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
         doc['an_refereed_citations'] = float(doc['refereed_citation_num'])/float(age)
         doc['rn_citations'] = ref_norm
         doc['rn_citation_data'] = rn_citation_data
+        doc['rn_citations_hist']=dict(rn_citations_hist)
 
     @classmethod
     def post_load_data(cls, session, source_collection):

--- a/adsdata/psql_models.py
+++ b/adsdata/psql_models.py
@@ -30,6 +30,7 @@ class Metrics(Base):
   refereed = Column(Boolean)
   rn_citations = Column(postgresql.REAL)
   rn_citation_data = Column(postgresql.JSON)
+  rn_citations_hist = Column(postgresql.JSON)
   downloads = Column(postgresql.ARRAY(Integer))
   reads = Column(postgresql.ARRAY(Integer))
   an_citations = Column(postgresql.REAL)

--- a/test/test.py
+++ b/test/test.py
@@ -449,6 +449,9 @@ class TestMetrics(AdsdataTestCase):
                                'refereed_citations': [u'1983ARA&A..21..373O', u'2000JOptB...2..534W', u'2000PhRvL..84.2094A', u'2001AJ....122..308G'],
                                'author_num': 1,
                                'an_refereed_citations': 4.0/age, #0.042105263157894736,
+                               'rn_citations_hist': {u'1983': 0.018867924528301886,
+                                                     u'2000': 0.089170328250193845,
+                                                     u'2001': 0.070302403721891962}
                                })
     def test_build_metrics_data(self):
         load_data(self.config)

--- a/test/test.py
+++ b/test/test.py
@@ -451,7 +451,8 @@ class TestMetrics(AdsdataTestCase):
                                'an_refereed_citations': 4.0/age, #0.042105263157894736,
                                'rn_citations_hist': {u'1983': 0.018867924528301886,
                                                      u'2000': 0.089170328250193845,
-                                                     u'2001': 0.070302403721891962}
+                                                     u'2001': 0.070302403721891962,
+                                                     u'2011': 0.27030240372189196}
                                })
     def test_build_metrics_data(self):
         load_data(self.config)


### PR DESCRIPTION
The `rn_citations_hist` column was reinstated, the database was augmented with a `reference_num` column of type INTEGER. Tests have been updated appropriately.