### PR TITLE
Added date fields to rn_citation_data for Tori time series calculation

### DIFF
--- a/adsdata/models.py
+++ b/adsdata/models.py
@@ -430,7 +430,7 @@ class Citations(DataFileCollection, DocsDataCollection, MetricsDataCollection):
                 Nrefs_normalized = 1.0/float(max(5, Nrefs))
                 ref_norm += Nrefs_normalized
                 rn_citations_hist[citation[:4]] += ref_norm
-                rn_citation_data.append({'bibcode':citation,'ref_norm':Nrefs_normalized,'auth_norm':auth_norm})
+                rn_citation_data.append({'bibcode':citation,'ref_norm':Nrefs_normalized,'auth_norm':auth_norm, 'pubyear': int(bibcode[:4]), 'cityear': int(citation[:4])})
             except:
                 pass
         doc['refereed'] = refereed

--- a/test/test.py
+++ b/test/test.py
@@ -438,7 +438,7 @@ class TestMetrics(AdsdataTestCase):
         self.assertEqual(doc, {'_id': '1920ApJ....51....4D',
                                'refereed': True,
                                'rn_citations': 0.270302403721891962,
-                               'rn_citation_data': [{'bibcode':u'1983ARA&A..21..373O','ref_norm':0.018867924528301886, 'auth_norm':1.0}, {'bibcode':u'2000JOptB...2..534W', 'ref_norm': 0.018867924528301886, 'auth_norm':1.0}, {'bibcode':u'2000PhRvL..84.2094A', 'ref_norm': 0.013698630136986301, 'auth_norm':1.0}, {'bibcode':u'2001AJ....122..308G','ref_norm': 0.018867924528301886, 'auth_norm':1.0}, {'bibcode': u'2011foobar........X', 'ref_norm': 0.2, 'auth_norm':1.0}],
+                               'rn_citation_data': [{'bibcode':u'1983ARA&A..21..373O','ref_norm':0.018867924528301886, 'auth_norm':1.0, 'pubyear': 1920, 'cityear': 1983}, {'bibcode':u'2000JOptB...2..534W', 'ref_norm': 0.018867924528301886, 'auth_norm':1.0, 'pubyear': 1920, 'cityear': 2000}, {'bibcode':u'2000PhRvL..84.2094A', 'ref_norm': 0.013698630136986301, 'auth_norm':1.0, 'pubyear': 1920, 'cityear': 2000}, {'bibcode':u'2001AJ....122..308G','ref_norm': 0.018867924528301886, 'auth_norm':1.0, 'pubyear': 1920, 'cityear': 2001}, {'bibcode': u'2011foobar........X', 'ref_norm': 0.2, 'auth_norm':1.0, 'pubyear': 1920, 'cityear': 2011}],
                                'downloads': [0, 0, 0, 5, 3, 3, 2, 6, 1, 8, 7, 2, 7, 3, 2, 0, 4, 5],
                                'reads': [0, 0, 0, 5, 4, 3, 3, 6, 1, 8, 12, 4, 7, 3, 2, 2, 8, 0],
                                'an_citations': 5.0/age, #0.052631578947368418,


### PR DESCRIPTION
Adding the years of the citing and cited papers are needed for an efficient calculation of the Tori time series