### PR TITLE
Small change to disable MongoDB update

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -72,9 +72,11 @@ class Builder(Process):
 
                 if self.do_metrics:
                     metrics = self.session.generate_metrics_data(bibcode)
-                    metrics_updated = self.session.store(metrics, self.session.metrics_data)
-                    if metrics_updated:
-                      self.psql['payload'].append(metrics)
+                    # We are no longer using the MongoDB collection
+                    #metrics_updated = self.session.store(metrics, self.session.metrics_data)
+                    #if metrics_updated:
+                    # The Postgres update checks if the record changed
+                    self.psql['payload'].append(metrics)
              
                 if len(self.psql['payload']) >= self.psql['payload_size']:
                     try:


### PR DESCRIPTION
A possible speedup in the check in `psql_session.py` to see if a record already exists is to check just the essential data. The histograms can be added to the `excluded_fields` list, for example. Probably just a marginal speedup compared to the rest of the process.